### PR TITLE
Add attribute caching and service changed protocols from the client side

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -127,6 +127,7 @@ struct hci_conn_update;
 #define BLE_GAP_EVENT_PERIODIC_SYNC         20
 #define BLE_GAP_EVENT_PERIODIC_REPORT       21
 #define BLE_GAP_EVENT_PERIODIC_SYNC_LOST    22
+#define BLE_GAP_EVENT_SERVICE_CHANGED_RX             25
 
 /*** Reason codes for the subscribe GAP event. */
 
@@ -693,6 +694,30 @@ struct ble_gap_event {
              */
             uint8_t indication:1;
         } notify_rx;
+
+        /**
+         * Represents a received indication from service changed chr.
+         *
+         * Valid for the following event types:
+         *     o BLE_GAP_EVENT_SERVICE_CHANGED_RX
+         */
+        struct {
+            /**
+            * The start Attribute Handle shall be the start Attribute Handle of
+            *                                         the service definition containing the change
+            */
+            uint16_t start_handle;
+
+            /**
+             * The end Attribute Handle shall   be the last Attribute Handle of the service definition
+             *                                         containing the change
+             .*/
+            uint16_t end_handle;
+
+            /** The handle of the relevant connection. */
+            uint16_t conn_handle;
+
+        } indicate_svc_changed_rx;
 
         /**
          * Represents a transmitted ATT notification or indication, or a

--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -116,7 +116,8 @@ typedef int ble_gatt_disc_svc_fn(uint16_t conn_handle,
                                  const struct ble_gatt_error *error,
                                  const struct ble_gatt_svc *service,
                                  void *arg);
-
+struct ble_gatt_error *
+ble_gattc_error(int status, uint16_t att_handle);
 /**
  * The host will free the attribute mbuf automatically after the callback is
  * executed.  The application can take ownership of the mbuf and prevent it

--- a/nimble/host/src/ble_att_caching.c
+++ b/nimble/host/src/ble_att_caching.c
@@ -1,0 +1,717 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "ble_att_caching.h"
+#include "ble_hs_priv.h"
+
+struct ble_att_caching_dsc {
+    SLIST_ENTRY(ble_att_caching_dsc) next;
+    struct ble_gatt_dsc dsc;
+};
+SLIST_HEAD(ble_att_caching_dsc_list, ble_att_caching_dsc);
+
+struct ble_att_caching_chr {
+    SLIST_ENTRY(ble_att_caching_chr) next;
+    struct ble_gatt_chr chr;
+    struct ble_att_caching_dsc_list dscs;
+    uint8_t all_dsc_cached;
+};
+SLIST_HEAD(ble_att_caching_chr_list, ble_att_caching_chr);
+
+struct ble_att_caching_svc {
+    SLIST_ENTRY(ble_att_caching_svc) next;
+    struct ble_gatt_svc svc;
+    struct ble_att_caching_chr_list chrs;
+    uint8_t all_chars_cached;
+};
+
+SLIST_HEAD(ble_att_caching_svc_list, ble_att_caching_svc);
+
+struct ble_att_caching_conn {
+    struct ble_att_caching_svc_list svcs;
+    /** Peer identity address */
+    ble_addr_t peer_id_addr;
+    uint16_t handle;
+    uint8_t all_services_cached;
+    uint16_t service_changed_att_handle;
+};
+
+static struct ble_att_caching_conn ble_att_caching_conns[MYNEWT_VAL(
+        BLE_MAX_CONNECTIONS)];
+static int ble_att_caching_num_conns = 0;
+
+static os_membuf_t ble_att_caching_svc_mem[OS_MEMPOOL_SIZE(
+        BLE_ATT_CASHING_MAX_SVCS, sizeof(struct ble_att_caching_svc))];
+static struct os_mempool ble_att_caching_svc_pool;
+
+static os_membuf_t ble_att_caching_chr_mem[OS_MEMPOOL_SIZE(
+        BLE_ATT_CASHING_MAX_CHRS, sizeof(struct ble_att_caching_chr))];
+static struct os_mempool ble_att_caching_chr_pool;
+
+static os_membuf_t ble_att_caching_dsc_mem[OS_MEMPOOL_SIZE(
+        BLE_ATT_CASHING_MAX_DSCS, sizeof(struct ble_att_caching_dsc))];
+static struct os_mempool ble_att_caching_dsc_pool;
+
+static void
+ble_att_caching_chr_delete(struct ble_att_caching_chr *chr)
+{
+    struct ble_att_caching_dsc *dsc;
+
+    while ((dsc = SLIST_FIRST(&chr->dscs)) != NULL) {
+        SLIST_REMOVE_HEAD(&chr->dscs, next);
+        os_memblock_put(&ble_att_caching_dsc_pool, dsc);
+    }
+
+    os_memblock_put(&ble_att_caching_chr_pool, chr);
+}
+
+static void
+ble_att_caching_svc_delete(struct ble_att_caching_svc *svc)
+{
+    struct ble_att_caching_chr *chr;
+
+    while ((chr = SLIST_FIRST(&svc->chrs)) != NULL) {
+        SLIST_REMOVE_HEAD(&svc->chrs, next);
+        ble_att_caching_chr_delete(chr);
+    }
+
+    os_memblock_put(&ble_att_caching_svc_pool, svc);
+}
+
+static int
+ble_att_caching_conn_find_idx(uint16_t handle)
+{
+    int i;
+
+    for (i = 0; i < ble_att_caching_num_conns; i++) {
+        if (ble_att_caching_conns[i].handle == handle) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static struct ble_att_caching_conn *
+ble_att_caching_conn_find(uint16_t handle)
+{
+    int idx;
+
+    idx = ble_att_caching_conn_find_idx(handle);
+    if (idx == -1) {
+        return NULL;
+    } else {
+        return ble_att_caching_conns + idx;
+    }
+}
+
+static struct ble_att_caching_svc *
+ble_att_caching_svc_find_prev(struct ble_att_caching_conn *conn,
+        uint16_t svc_start_handle)
+{
+    struct ble_att_caching_svc *prev;
+    struct ble_att_caching_svc *svc;
+
+    prev = NULL;
+    SLIST_FOREACH(svc, &conn->svcs, next)
+    {
+        if (svc->svc.start_handle >= svc_start_handle) {
+            break;
+        }
+
+        prev = svc;
+    }
+
+    return prev;
+}
+
+static struct ble_att_caching_svc *
+ble_att_caching_svc_find(struct ble_att_caching_conn *conn,
+        uint16_t svc_start_handle, struct ble_att_caching_svc **out_prev)
+{
+    struct ble_att_caching_svc *prev;
+    struct ble_att_caching_svc *svc;
+
+    prev = ble_att_caching_svc_find_prev(conn, svc_start_handle);
+    if (prev == NULL) {
+        svc = SLIST_FIRST(&conn->svcs);
+    } else {
+        svc = SLIST_NEXT(prev, next);
+    }
+
+    if (svc != NULL && svc->svc.start_handle != svc_start_handle) {
+        svc = NULL;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+    return svc;
+}
+
+static struct ble_att_caching_svc *
+ble_att_caching_svc_find_range(struct ble_att_caching_conn *conn,
+        uint16_t attr_handle)
+{
+    struct ble_att_caching_svc *svc;
+
+    SLIST_FOREACH(svc, &conn->svcs, next)
+    {
+        if (svc->svc.start_handle <= attr_handle
+                && svc->svc.end_handle >= attr_handle) {
+
+            return svc;
+        }
+    }
+
+    return NULL;
+}
+
+static struct ble_att_caching_dsc *
+ble_att_caching_dsc_find_prev(const struct ble_att_caching_chr *chr,
+        uint16_t dsc_handle)
+{
+    struct ble_att_caching_dsc *prev;
+    struct ble_att_caching_dsc *dsc;
+
+    prev = NULL;
+    SLIST_FOREACH(dsc, &chr->dscs, next)
+    {
+        if (dsc->dsc.handle >= dsc_handle) {
+            break;
+        }
+
+        prev = dsc;
+    }
+
+    return prev;
+}
+
+static struct ble_att_caching_dsc *
+ble_att_caching_dsc_find(const struct ble_att_caching_chr *chr,
+        uint16_t dsc_handle, struct ble_att_caching_dsc **out_prev)
+{
+    struct ble_att_caching_dsc *prev;
+    struct ble_att_caching_dsc *dsc;
+
+    prev = ble_att_caching_dsc_find_prev(chr, dsc_handle);
+    if (prev == NULL) {
+        dsc = SLIST_FIRST(&chr->dscs);
+    } else {
+        dsc = SLIST_NEXT(prev, next);
+    }
+
+    if (dsc != NULL && dsc->dsc.handle != dsc_handle) {
+        dsc = NULL;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+    return dsc;
+}
+
+static struct ble_att_caching_chr *
+ble_att_caching_chr_find_prev(const struct ble_att_caching_svc *svc,
+        uint16_t chr_val_handle)
+{
+    struct ble_att_caching_chr *prev;
+    struct ble_att_caching_chr *chr;
+
+    prev = NULL;
+    SLIST_FOREACH(chr, &svc->chrs, next)
+    {
+        if (chr->chr.val_handle >= chr_val_handle) {
+            break;
+        }
+
+        prev = chr;
+    }
+
+    return prev;
+}
+
+static struct ble_att_caching_chr *
+ble_att_caching_chr_find(const struct ble_att_caching_svc *svc,
+        uint16_t chr_val_handle, struct ble_att_caching_chr **out_prev)
+{
+    struct ble_att_caching_chr *prev;
+    struct ble_att_caching_chr *chr;
+
+    prev = ble_att_caching_chr_find_prev(svc, chr_val_handle);
+    if (prev == NULL) {
+        chr = SLIST_FIRST(&svc->chrs);
+    } else {
+        chr = SLIST_NEXT(prev, next);
+    }
+
+    if (chr != NULL && chr->chr.val_handle != chr_val_handle) {
+        chr = NULL;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+    return chr;
+}
+
+struct ble_att_caching_conn *
+ble_att_caching_conn_add(struct ble_gap_conn_desc *desc)
+{
+    struct ble_att_caching_conn *conn;
+    BLE_HS_DBG_ASSERT(
+            ble_att_caching_num_conns < MYNEWT_VAL(BLE_MAX_CONNECTIONS));
+
+    conn = ble_att_caching_conns + ble_att_caching_num_conns;
+    ble_att_caching_num_conns++;
+
+    conn->handle = desc->conn_handle;
+    conn->peer_id_addr = desc->peer_id_addr;
+    SLIST_INIT(&conn->svcs);
+    return conn;
+}
+
+int
+ble_att_caching_svc_add(uint16_t conn_handle,
+        const struct ble_gatt_svc *gatt_svc)
+{
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_svc *prev;
+    struct ble_att_caching_svc *svc;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+
+    svc = ble_att_caching_svc_find(conn, gatt_svc->start_handle, &prev);
+    if (svc != NULL) {
+        /* Service already discovered. */
+        return 0;
+    }
+
+    svc = os_memblock_get(&ble_att_caching_svc_pool);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "OOM WHILE DISCOVERING SERVICE\n");
+        return BLE_HS_ENOMEM;
+    }
+    memset(svc, 0, sizeof *svc);
+
+    svc->svc = *gatt_svc;
+    SLIST_INIT(&svc->chrs);
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&conn->svcs, svc, next);
+    } else {
+        SLIST_INSERT_AFTER(prev, svc, next);
+    }
+
+    return 0;
+}
+
+int
+ble_att_caching_set_all_services_cached(uint16_t conn_handle)
+{
+    struct ble_att_caching_conn *conn;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+    conn->all_services_cached = 1;
+    return 0;
+}
+
+int
+ble_att_caching_set_all_chrs_cached(uint16_t conn_handle, uint16_t start_handle)
+{
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_svc *svc;
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+
+    svc = ble_att_caching_svc_find(conn, start_handle, NULL);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+    svc->all_chars_cached = 1;
+    return 0;
+}
+
+int
+ble_att_caching_set_all_dscs_cached(uint16_t conn_handle, uint16_t chr_val_handle)
+{
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_svc *svc;
+    struct ble_att_caching_chr *chr;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+    svc = ble_att_caching_svc_find_range(conn, chr_val_handle);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+
+    chr = ble_att_caching_chr_find(svc, chr_val_handle, NULL);
+    if (chr == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND CHARACTERISTIC FOR DISCOVERED DSC; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+    chr->all_dsc_cached = 1;
+    return 0;
+}
+
+int
+ble_att_caching_check_if_services_cached(uint16_t conn_handle)
+{
+    struct ble_gap_conn_desc desc;
+    struct ble_att_caching_conn *conn;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+   ble_gap_conn_find(conn_handle, &desc);
+
+    /* Check bonded , all services cached and they have
+     *  the same address at the same time. */
+    if (desc.sec_state.bonded && conn->all_services_cached
+            && !ble_addr_cmp((const ble_addr_t *) &conn->peer_id_addr,
+                    (const ble_addr_t *) &desc.peer_id_addr)) {
+        /* Then don`t discover. */
+        return 0;
+    }
+
+    return BLE_HS_EINVAL;
+}
+
+int
+ble_att_caching_check_if_chars_cached(uint16_t conn_handle,
+        uint16_t start_handle, ble_gatt_chr_fn *cb, void *cb_arg)
+{
+    struct ble_gap_conn_desc desc;
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_svc *svc;
+    struct ble_att_caching_chr *chr;
+    int status = 0;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+    ble_gap_conn_find(conn_handle, &desc);
+    svc = ble_att_caching_svc_find(conn, start_handle, NULL);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED CHR; HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+    /* Check bonded , all services cached and they have
+     *  the same address at the same time. */
+    if (desc.sec_state.bonded && svc->all_chars_cached
+            && !ble_addr_cmp((const ble_addr_t *) &conn->peer_id_addr,
+                    (const ble_addr_t *) &desc.peer_id_addr)) {
+        SLIST_FOREACH(chr, &svc->chrs, next)
+        {
+           cb(conn_handle, ble_gattc_error(status, 0), &chr->chr, cb_arg);
+        }
+        status = BLE_HS_EDONE;
+        cb(conn_handle, ble_gattc_error(status, 0), &chr->chr, cb_arg);
+        /* Then don`t discover. */
+    }
+
+    return BLE_HS_EINVAL;
+}
+
+int
+ble_att_caching_check_if_dsc_cached(uint16_t conn_handle,
+        uint16_t chr_val_handle, ble_gatt_dsc_fn *cb, void *cb_arg)
+{
+    struct ble_gap_conn_desc desc;
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_svc *svc;
+    struct ble_att_caching_chr *chr;
+    struct ble_att_caching_dsc *dsc;
+    int status = 0;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+    ble_gap_conn_find(conn_handle, &desc);
+    svc = ble_att_caching_svc_find_range(conn, chr_val_handle);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+
+    chr = ble_att_caching_chr_find(svc, chr_val_handle, NULL);
+    if (chr == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND CHARACTERISTIC FOR DISCOVERED DSC; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+    /* Check bonded , all services cached and they have
+     *  the same address at the same time. */
+    if (desc.sec_state.bonded && chr->all_dsc_cached
+            && !ble_addr_cmp((const ble_addr_t *) &conn->peer_id_addr,
+                    (const ble_addr_t *) &desc.peer_id_addr)) {
+        SLIST_FOREACH(dsc, &chr->dscs, next)
+        {
+            cb(conn_handle, ble_gattc_error(status, 0), chr_val_handle,
+                    &dsc->dsc, cb_arg);
+        }
+        status = BLE_HS_EDONE;
+        cb(conn_handle, ble_gattc_error(status, 0), chr_val_handle, &dsc->dsc,
+                cb_arg);
+        /* Then don`t discover. */
+        return 0;
+    }
+
+    return BLE_HS_EINVAL;
+}
+
+void
+ble_att_caching_notify_application_with_cached_services(
+        uint16_t conn_handle, ble_gatt_disc_svc_fn *cb, void *cb_arg)
+{
+    struct ble_att_caching_svc *svc;
+    struct ble_att_caching_conn *conn;
+    int status = 0;
+    conn = ble_att_caching_conn_find(conn_handle);
+
+    SLIST_FOREACH(svc, &conn->svcs, next)
+    {
+        cb(conn_handle, ble_gattc_error(status, 0), &svc->svc, cb_arg);
+    }
+    status = BLE_HS_EDONE;
+    cb(conn_handle, ble_gattc_error(status, 0), &svc->svc, cb_arg);
+
+}
+
+int ble_att_caching_chr_add(uint16_t conn_handle, uint16_t svc_start_handle,
+        const struct ble_gatt_chr *gatt_chr)
+{
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_chr *prev;
+    struct ble_att_caching_chr *chr;
+    struct ble_att_caching_svc *svc;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+
+    svc = ble_att_caching_svc_find(conn, svc_start_handle, NULL);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED CHR; HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+
+    chr = ble_att_caching_chr_find(svc, gatt_chr->val_handle, &prev);
+    if (chr != NULL) {
+        /* Characteristic already discovered. */
+        return 0;
+    }
+
+    chr = os_memblock_get(&ble_att_caching_chr_pool);
+    if (chr == NULL) {
+        BLE_HS_LOG(DEBUG, "OOM WHILE DISCOVERING CHARACTERISTIC\n");
+        return BLE_HS_ENOMEM;
+    }
+    memset(chr, 0, sizeof *chr);
+
+    chr->chr = *gatt_chr;
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&svc->chrs, chr, next);
+    } else {
+        SLIST_NEXT(prev, next) = chr;
+    }
+
+    return 0;
+}
+
+int
+ble_att_caching_dsc_add(uint16_t conn_handle, uint16_t chr_val_handle,
+        const struct ble_gatt_dsc *gatt_dsc)
+{
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_dsc *prev;
+    struct ble_att_caching_dsc *dsc;
+    struct ble_att_caching_svc *svc;
+    struct ble_att_caching_chr *chr;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+
+    svc = ble_att_caching_svc_find_range(conn, chr_val_handle);
+    if (svc == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+
+    chr = ble_att_caching_chr_find(svc, chr_val_handle, NULL);
+    if (chr == NULL) {
+        BLE_HS_LOG(DEBUG, "CAN'T FIND CHARACTERISTIC FOR DISCOVERED DSC; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_EINVAL;
+    }
+    if (!ble_uuid_cmp(
+            BLE_UUID16_DECLARE(BLE_SVC_GATT_CHR_SERVICE_CHANGED_UUID16),
+            (const ble_uuid_t *) &chr->chr.uuid)) {
+        conn->service_changed_att_handle = chr->chr.val_handle;
+    }
+    dsc = ble_att_caching_dsc_find(chr, gatt_dsc->handle, &prev);
+    if (dsc != NULL) {
+        /* Descriptor already discovered. */
+        return 0;
+    }
+
+    dsc = os_memblock_get(&ble_att_caching_dsc_pool);
+    if (dsc == NULL) {
+        BLE_HS_LOG(DEBUG,"OOM WHILE DISCOVERING DESCRIPTOR\n");
+        return BLE_HS_ENOMEM;
+    }
+    memset(dsc, 0, sizeof *dsc);
+
+    dsc->dsc = *gatt_dsc;
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&chr->dscs, dsc, next);
+    } else {
+        SLIST_NEXT(prev, next) = dsc;
+    }
+
+    return 0;
+}
+
+uint16_t
+ble_att_caching_get_service_changed_att_handle(uint16_t conn_handle)
+{
+    struct ble_att_caching_conn *conn;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+    return conn->service_changed_att_handle;
+}
+
+int
+ble_att_caching_service_changed_rx(uint16_t conn_handle,
+        uint16_t start_handle, uint16_t end_handle)
+{
+    struct ble_att_caching_conn *conn;
+    struct ble_att_caching_svc *svc;
+    struct ble_att_caching_svc *prev;
+    uint16_t svc_end_handle;
+
+    conn = ble_att_caching_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        return BLE_HS_ENOTCONN;
+    }
+    conn->all_services_cached = 0;
+    svc = ble_att_caching_svc_find(conn, start_handle, &prev);
+    if (svc == NULL) {
+        /* Service not found. */
+        return BLE_HS_EINVAL;
+    }
+    for (; svc; svc = SLIST_NEXT((prev), next)) {
+        svc_end_handle = svc->svc.end_handle;
+        SLIST_NEXT((prev), next) = SLIST_NEXT((svc), next);
+        ble_att_caching_svc_delete(svc);
+        if (svc_end_handle == end_handle) {
+            break;
+        }
+    }
+    return 0;
+
+}
+
+int
+ble_att_caching_init(void)
+{
+    int rc;
+    rc = os_mempool_init(&ble_att_caching_svc_pool, BLE_ATT_CASHING_MAX_SVCS,
+            sizeof(struct ble_att_caching_svc), ble_att_caching_svc_mem,
+            "ble_att_caching_svc_pool");
+    BLE_HS_DBG_ASSERT(rc == 0);
+
+    rc = os_mempool_init(&ble_att_caching_chr_pool, BLE_ATT_CASHING_MAX_CHRS,
+            sizeof(struct ble_att_caching_chr), ble_att_caching_chr_mem,
+            "ble_att_caching_chr_pool");
+    BLE_HS_DBG_ASSERT(rc == 0);
+
+    rc = os_mempool_init(&ble_att_caching_dsc_pool, BLE_ATT_CASHING_MAX_DSCS,
+            sizeof(struct ble_att_caching_dsc), ble_att_caching_dsc_mem,
+            "ble_att_caching_dsc_pool");
+    BLE_HS_DBG_ASSERT(rc == 0);
+    return rc;
+}

--- a/nimble/host/src/ble_att_caching.h
+++ b/nimble/host/src/ble_att_caching.h
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef  BLE_ATT_CACHING_H_
+#define BLE_ATT_CACHING_H_
+
+/**
+ * @brief Attribute caching is an optimization that allows the client to discover the
+ * @         Attribute information such as Attribute Handles used by the server once and
+ * @         use the same Attribute information across re-connections without re-discovery.
+ * @ingroup bt_att_caching
+ * @defgroup bt_host
+ * @{
+ */
+
+#include "syscfg/syscfg.h"
+#include "os/queue.h"
+#include "host/ble_gap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLE_ATT_CASHING_MAX_SVCS               32
+#define BLE_ATT_CASHING_MAX_CHRS               64
+#define BLE_ATT_CASHING_MAX_DSCS               64
+#define BLE_SVC_GATT_CHR_SERVICE_CHANGED_UUID16     0x2a05
+
+/**
+ * Add new attribute connection for caching
+ *
+ * Add new connection till the max number of connection is reached,
+ * save connection handle and peer Identity address and initialize the list
+ * of services per connection.
+ * This function Must be called one time for the same device over re-connections.
+ *
+ * @param desc      A pointer to the current connection descriptor
+ *
+ * @return              Attribute caching connection structure
+ */
+struct ble_att_caching_conn *
+ble_att_caching_conn_add(struct ble_gap_conn_desc *desc);
+
+/**
+ * Add service in order in the same connection.
+ *
+ * Add the discovered service to the cached list for the same connection,
+ * if the service is already found in the list return it,
+ * else create a new one from ble_att_caching_svc_pool.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param gatt_svc             The service to be cached
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOMEM if out of memory, no more memory pools
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found.
+ */
+int
+ble_att_caching_svc_add(uint16_t conn_handle,
+        const struct ble_gatt_svc *gatt_svc);
+
+/**
+ * Add characteristic in order in the same connection.
+ *
+ * Add the discovered characteristic to the cached list for the same service,
+ * if the characteristic is already found in the list return it,
+ * else create a new one from ble_att_caching_chr_pool.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param svc_start_handle      start handle in the service range
+ * @param gatt_chr             The characteristic to be cached
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOMEM if out of memory, no more memory pools
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL if no list to add the char to.
+ */
+int
+ble_att_caching_chr_add(uint16_t conn_handle, uint16_t svc_start_handle,
+        const struct ble_gatt_chr *gatt_chr);
+
+/**
+ * Add descriptor in order in the same connection.
+ *
+ * Add the discovered descriptor to the cached list for the same characteristic,
+ * if the descriptor is already found in the list return it,
+ * else create a new one from ble_att_caching_dsc_pool.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param chr_val_handle  characteristic value handle
+ * @param gatt_chr             The descriptor to be cached
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOMEM if out of memory, no more memory pools
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL if no list to add the dsc to.
+ */
+int
+ble_att_caching_dsc_add(uint16_t conn_handle, uint16_t chr_val_handle,
+        const struct ble_gatt_dsc *gatt_dsc);
+
+/**
+ * After discover all services this function must be called to indicate att_caching
+ * that all services are already cached.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found. */
+int
+ble_att_caching_set_all_services_cached(uint16_t conn_handle);
+
+/**
+ * After discover all characteristics this function must be called to indicate att_caching
+ * that all characteristics are already cached for a specific service.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param start_handle     start handle in the service range
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL if no list to add the char to.
+ */
+int
+ble_att_caching_set_all_chrs_cached(uint16_t conn_handle, uint16_t start_handle);
+
+/**
+ * After discover all descriptors this function must be called to indicate att_caching
+ * that all descriptors are already cached for a specific characteristic.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param chr_val_handle  characteristic value handle
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL if no list to add the char to.
+ */
+int
+ble_att_caching_set_all_dscs_cached(uint16_t conn_handle, uint16_t chr_val_handle);
+
+/**
+ * Check if we need to discover server's attribute (services) or the server had a bond with this
+ * client, the client cached all these attribute and this is the same server address from the
+ * previous connection.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ *
+ * @return               0  don't discover as all services are already cached
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL We need to discover as of the three concisions is violated.
+ */
+int
+ble_att_caching_check_if_services_cached(uint16_t conn_handle);
+
+/**
+ * If all services are already cached, we will not discover on air we need to
+ * notify the app with all cached services.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param cb                    The function to call to report procedure status
+ *                                  updates; null for no callback.
+ * @param cb_arg                The optional argument to pass to the callback
+ *                                  function.
+ * @return              Void
+ */
+void
+ble_att_caching_notify_application_with_cached_services(uint16_t conn_handle,
+        ble_gatt_disc_svc_fn *cb, void *cb_arg);
+
+/**
+ * Check if we need to discover server's attribute (characteristics) or the server had a bond with this
+ * client, the client cached all these attribute and this is the same server address from the
+ * previous connection.
+ * If all characteristics are already cached, we will not discover on air we need to
+ * notify the app with all cached chars.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param cb                    The function to call to report procedure status
+ *                                  updates; null for no callback.
+ * @param cb_arg                The optional argument to pass to the callback
+ *                                  function.
+ *
+ * @return               0  don't discover as all services are already cached
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL We need to discover as of the three concisions is violated.
+ */
+int
+ble_att_caching_check_if_chars_cached(uint16_t conn_handle,
+        uint16_t start_handle, ble_gatt_chr_fn *cb, void *cb_arg);
+
+/**
+ * Check if we need to discover server's attribute (descriptors) or the server had a bond with this
+ * client, the client cached all these attribute and this is the same server address from the
+ * previous connection.
+ * If all descriptors are already cached, we will not discover on air we need to
+ * notify the app with all cached chars.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+  * @param chr_val_handle      characteristic value handle
+ * @param cb                    The function to call to report procedure status
+ *                                  updates; null for no callback.
+ * @param cb_arg                The optional argument to pass to the callback
+ *                                  function.
+ *
+ * @return               0  don't discover as all services are already cached
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL We need to discover as of the three concisions is violated.
+ */
+int
+ble_att_caching_check_if_dsc_cached(uint16_t conn_handle,
+        uint16_t chr_val_handle, ble_gatt_dsc_fn *cb, void *cb_arg);
+
+/**
+ * Get the attribute handle stored for service changed characteristic.
+ *
+ * * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ *
+ * @return              service changed attribute handle
+ */
+uint16_t
+ble_att_caching_get_service_changed_att_handle(uint16_t conn_handle);
+
+/**
+ * When receive indication the a specific range of attribute is changed, delete all stored
+ * attribute in attribute caching.
+ *
+ * @param conn_handle      connection handle for the current connection
+ *                                        from the gap descriptor
+ * @param start_handle  The start Attribute Handle shall be the start Attribute Handle of
+ *                                         the service definition containing the change
+ * @param end_handle   The end Attribute Handle shall
+ *                                         be the last Attribute Handle of the service definition
+ *                                         containing the change.
+ *
+ * @return               0  on success
+ *                      BLE_HS_ENOTCONN if no matching connection was
+ *                  found
+ *                      BLE_HS_EINVAL service is not found with that start handle.
+ */
+int
+ble_att_caching_service_changed_rx(uint16_t conn_handle, uint16_t start_handle,
+        uint16_t end_handle);
+
+/**
+ * Initialize services, characteristics and descriptors memory pools.
+ *
+ * @return            0  on success
+ */
+int
+ble_att_caching_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* BLE_ATT_CACHING_H_ */

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -23,6 +23,7 @@
 #include "nimble/nimble_opt.h"
 #include "host/ble_hs_adv.h"
 #include "host/ble_hs_hci.h"
+#include "ble_att_caching.h"
 #include "ble_hs_priv.h"
 
 #if MYNEWT
@@ -5320,11 +5321,23 @@ ble_gap_notify_rx_event(uint16_t conn_handle, uint16_t attr_handle,
     struct ble_gap_event event;
 
     memset(&event, 0, sizeof event);
+    if (attr_handle == ble_att_caching_get_service_changed_att_handle(conn_handle)) {
+        uint16_t start_handle;
+        uint16_t end_handle;
+        start_handle = get_le16(om->om_data);
+        end_handle = get_le16(om ->om_data + 2);
+        ble_att_caching_service_changed_rx(conn_handle,start_handle,end_handle);
+        event.type = BLE_GAP_EVENT_SERVICE_CHANGED_RX;
+        event.indicate_svc_changed_rx.conn_handle = conn_handle;
+        event.indicate_svc_changed_rx.start_handle = start_handle;
+        event.indicate_svc_changed_rx.end_handle = end_handle;
+    } else {
     event.type = BLE_GAP_EVENT_NOTIFY_RX;
     event.notify_rx.conn_handle = conn_handle;
     event.notify_rx.attr_handle = attr_handle;
     event.notify_rx.om = om;
     event.notify_rx.indication = is_indication;
+	}
     ble_gap_event_listener_call(&event);
     ble_gap_call_conn_event_cb(&event, conn_handle);
 

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -58,6 +58,7 @@
 #include "nimble/ble.h"
 #include "host/ble_uuid.h"
 #include "host/ble_gap.h"
+#include "ble_att_caching.h"
 #include "ble_hs_priv.h"
 
 /*****************************************************************************
@@ -1197,7 +1198,7 @@ ble_gattc_timer(void)
  * returned object is statically allocated, so this function is not reentrant.
  * This function should only ever be called by the ble_hs task.
  */
-static struct ble_gatt_error *
+struct ble_gatt_error *
 ble_gattc_error(int status, uint16_t att_handle)
 {
     static struct ble_gatt_error error;
@@ -1352,6 +1353,17 @@ ble_gattc_disc_all_svcs_cb(struct ble_gattc_proc *proc,
     if (proc->disc_all_svcs.cb == NULL) {
         rc = 0;
     } else {
+        switch (status) {
+        case 0:
+    		ble_att_caching_svc_add(proc->conn_handle,service);
+            break;
+
+        case BLE_HS_EDONE:
+            ble_att_caching_set_all_services_cached(proc->conn_handle);
+			break;
+        default:
+            BLE_HS_LOG(INFO, "error with conn_handle= %d\n",proc->conn_handle);
+        }
         rc = proc->disc_all_svcs.cb(proc->conn_handle,
                                     ble_gattc_error(status, att_handle),
                                     service, proc->disc_all_svcs.cb_arg);
@@ -1516,8 +1528,23 @@ ble_gattc_disc_all_svcs(uint16_t conn_handle, ble_gatt_disc_svc_fn *cb,
 #endif
 
     struct ble_gattc_proc *proc;
+    struct ble_gap_conn_desc desc;
+    struct ble_store_value_sec value_sec;
+    struct ble_store_key_sec key_sec;
     int rc;
+    rc = ble_gap_conn_find(conn_handle, &desc);
+    memset(&key_sec, 0, sizeof key_sec);
+    key_sec.peer_addr = desc.peer_id_addr;
 
+    rc = ble_store_read_peer_sec(&key_sec, &value_sec);
+    if (rc == 5 && !value_sec.ltk_present) {
+    ble_att_caching_conn_add(&desc);
+    }
+    rc = ble_att_caching_check_if_services_cached(conn_handle);
+    if(rc == 0) {
+    	ble_att_caching_notify_application_with_cached_services(conn_handle,cb,cb_arg);
+    	return rc;
+    }
     STATS_INC(ble_gattc_stats, disc_all_svcs);
 
     proc = ble_gattc_proc_alloc();
@@ -2106,6 +2133,20 @@ ble_gattc_disc_all_chrs_cb(struct ble_gattc_proc *proc, int status,
     if (proc->disc_all_chrs.cb == NULL) {
         rc = 0;
     } else {
+	    uint16_t* svc_start_handle;
+	    svc_start_handle = (uint16_t*)proc->disc_all_chrs.cb_arg;
+
+        switch (status) {
+        case 0:
+            ble_att_caching_chr_add(proc->conn_handle, *svc_start_handle, chr);
+            break;
+
+        case BLE_HS_EDONE:
+            ble_att_caching_set_all_chrs_cached(proc->conn_handle,*svc_start_handle);
+			break;
+        default:
+            BLE_HS_LOG(INFO, "error with conn_handle= %d\n",proc->conn_handle);
+        }
         rc = proc->disc_all_chrs.cb(proc->conn_handle,
                                     ble_gattc_error(status, att_handle), chr,
                                     proc->disc_all_chrs.cb_arg);
@@ -2275,6 +2316,10 @@ ble_gattc_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
     struct ble_gattc_proc *proc;
     int rc;
 
+    rc = ble_att_caching_check_if_chars_cached(conn_handle,start_handle,cb,cb_arg);
+    if(rc == 0) {
+    	return rc;
+    }
     STATS_INC(ble_gattc_stats, disc_all_chrs);
 
     proc = ble_gattc_proc_alloc();
@@ -2574,6 +2619,17 @@ ble_gattc_disc_all_dscs_cb(struct ble_gattc_proc *proc, int status,
     if (proc->disc_all_dscs.cb == NULL) {
         rc = 0;
     } else {
+        switch (status) {
+        case 0:
+        	ble_att_caching_dsc_add(proc->conn_handle, proc->disc_all_dscs.chr_val_handle, dsc);
+            break;
+
+        case BLE_HS_EDONE:
+            ble_att_caching_set_all_dscs_cached(proc->conn_handle,proc->disc_all_dscs.chr_val_handle);
+			break;
+        default:
+            BLE_HS_LOG(INFO, "error with conn_handle= %d\n",proc->conn_handle);
+        }
         rc = proc->disc_all_dscs.cb(proc->conn_handle,
                                     ble_gattc_error(status, att_handle),
                                     proc->disc_all_dscs.chr_val_handle,
@@ -2723,7 +2779,10 @@ ble_gattc_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
 
     struct ble_gattc_proc *proc;
     int rc;
-
+    rc = ble_att_caching_check_if_dsc_cached(conn_handle,start_handle,cb,cb_arg);
+    if(rc == 0) {
+    	return rc;
+    }
     STATS_INC(ble_gattc_stats, disc_all_dscs);
 
     proc = ble_gattc_proc_alloc();

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -753,6 +753,9 @@ ble_hs_init(void)
     rc = ble_att_init();
     SYSINIT_PANIC_ASSERT(rc == 0);
 
+    rc = ble_att_caching_init();
+    SYSINIT_PANIC_ASSERT(rc == 0);
+
     rc = ble_att_svr_init();
     SYSINIT_PANIC_ASSERT(rc == 0);
 

--- a/nimble/host/src/ble_hs_priv.h
+++ b/nimble/host/src/ble_hs_priv.h
@@ -43,6 +43,7 @@
 #include "ble_hs_id_priv.h"
 #include "ble_hs_periodic_sync_priv.h"
 #include "ble_uuid_priv.h"
+#include "ble_att_caching.h"
 #include "host/ble_hs.h"
 #include "host/ble_monitor.h"
 #include "nimble/nimble_opt.h"


### PR DESCRIPTION
Add ble_att_caching.c/h to store services, characteristics, and descriptors on the client side. the basic concept is an optimization that allows the client to discover the Attribute information such as Attribute Handles used by the server once.
