### PR TITLE
Add robust caching logic, database hash and client supported features…

### DIFF
--- a/nimble/host/include/host/ble_att.h
+++ b/nimble/host/include/host/ble_att.h
@@ -33,11 +33,17 @@ extern "C" {
 #endif
 
 struct os_mbuf;
-
+#define BLE_ATT_SVR_HASH_KEY_SIZE_IN_BYTES               16
 #define BLE_ATT_UUID_PRIMARY_SERVICE        0x2800
 #define BLE_ATT_UUID_SECONDARY_SERVICE      0x2801
 #define BLE_ATT_UUID_INCLUDE                0x2802
 #define BLE_ATT_UUID_CHARACTERISTIC         0x2803
+#define BLE_ATT_UUID_CHARACTERISTIC_EXTENDED_PROPERTIES         0x2900
+#define BLE_ATT_UUID_CHARACTERISTIC_USER_DESCRIPTION        0x2901
+#define BLE_ATT_UUID_CLIENT_CHARACTERISTICS_CONFIGURATION   0x2902
+#define BLE_ATT_UUID_SERVER_CHARACTERISTICS_CONFIGURATION   0x2903
+#define BLE_ATT_UUID_CHARACTERISTIC_PRESENTATION_FORMAT     0x2904
+#define BLE_ATT_UUID_CHARACTERISTIC_AGGREGATE_FORMAT        0x2905
 
 #define BLE_ATT_ERR_INVALID_HANDLE          0x01
 #define BLE_ATT_ERR_READ_NOT_PERMITTED      0x02
@@ -56,6 +62,9 @@ struct os_mbuf;
 #define BLE_ATT_ERR_INSUFFICIENT_ENC        0x0f
 #define BLE_ATT_ERR_UNSUPPORTED_GROUP       0x10
 #define BLE_ATT_ERR_INSUFFICIENT_RES        0x11
+#define BLE_ATT_ERR_DATA_OUT_OF_SYNC        0x12
+
+#define BLE_SVC_GATT_CHR_DATABASE_HASH_UUID16                 0x2b2a
 
 #define BLE_ATT_OP_ERROR_RSP                0x01
 #define BLE_ATT_OP_MTU_REQ                  0x02
@@ -182,6 +191,24 @@ uint16_t ble_att_preferred_mtu(void);
  *                                  within the allowed range.
  */
 int ble_att_set_preferred_mtu(uint16_t mtu);
+
+int
+ble_att_svr_calculate_database_hash(void);
+
+void
+ble_hs_conn_set_awareness(uint16_t conn_handle, uint8_t aware);
+
+void
+ble_hs_conn_set_all_awareness(uint8_t aware);
+
+void
+ble_hs_conn_check_set_awareness_if_bonding(uint16_t conn_handle,
+        uint8_t aware);
+
+uint8_t
+ble_hs_conn_get_awareness(uint16_t conn_handle);
+
+uint8_t* ble_att_svr_get_database_hash(void);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -30,6 +30,9 @@ extern "C" {
 #define BLE_STORE_OBJ_TYPE_OUR_SEC      1
 #define BLE_STORE_OBJ_TYPE_PEER_SEC     2
 #define BLE_STORE_OBJ_TYPE_CCCD         3
+#define BLE_STORE_OBJ_TYPE_CHANGE_ALL_AWARENESS         4
+#define BLE_STORE_OBJ_TYPE_CHANGE_AWARENESS         5
+
 
 /** Failed to persist record; insufficient storage capacity. */
 #define BLE_STORE_EVENT_OVERFLOW        1
@@ -85,6 +88,7 @@ struct ble_store_value_sec {
 
     unsigned authenticated:1;
     uint8_t sc:1;
+    uint8_t aware;
 };
 
 /**

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -88,7 +88,7 @@ struct ble_store_value_sec {
 
     unsigned authenticated:1;
     uint8_t sc:1;
-    uint8_t aware;
+    uint8_t aware:1;
 };
 
 /**

--- a/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
+++ b/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
@@ -37,7 +37,7 @@ struct ble_hs_cfg;
 void
 ble_svc_gatt_changed(uint16_t start_handle, uint16_t end_handle);
 bool
-ble_svc_gatt_is_client_support_robust_caching(void);
+ble_svc_gatt_is_client_robust_caching_supported(void);
 int
 ble_svc_gatt_update_database_hash(void);
 void ble_svc_gatt_init(void);

--- a/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
+++ b/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
@@ -28,9 +28,18 @@ extern "C" {
 
 struct ble_hs_cfg;
 
-#define BLE_SVC_GATT_CHR_SERVICE_CHANGED_UUID16     0x2a05
+#define BLE_SVC_GATT_CHR_SERVICE_CHANGED_UUID16     		  0x2a05
+#define BLE_SVC_GATT_CHR_CLIENT_SUPPORTED_FEATURES_UUID16     0x2b29
+#define BLE_SVC_GATT_CHR_DATABASE_HASH_UUID16     			  0x2b2a
+/* TODO: Update EATT_SUPPORTED_UUID16 based on SIG Assigned Numbers */
+#define BLE_SVC_GATT_CHR_EATT_SUPPORTED_UUID16     			  0x2b2c
 
-void ble_svc_gatt_changed(uint16_t start_handle, uint16_t end_handle);
+void
+ble_svc_gatt_changed(uint16_t start_handle, uint16_t end_handle);
+bool
+ble_svc_gatt_is_client_support_robust_caching(void);
+int
+ble_svc_gatt_update_database_hash(void);
 void ble_svc_gatt_init(void);
 
 #ifdef __cplusplus

--- a/nimble/host/services/gatt/src/ble_svc_gatt.c
+++ b/nimble/host/services/gatt/src/ble_svc_gatt.c
@@ -23,9 +23,22 @@
 #include "host/ble_hs.h"
 #include "services/gatt/ble_svc_gatt.h"
 
+
+#define CLIENT_SUPPORTED_FEATURES_MAX_OCTETS        (1)
+typedef enum {
+    ROBUST_CACHING = 0,
+    MAX_SUPPORTED_FEATURES
+} client_supported_features;
+
+static struct ble_gap_event_listener ble_svc_gatt_gap_listener;
+
 static uint16_t ble_svc_gatt_changed_val_handle;
 static uint16_t ble_svc_gatt_start_handle;
 static uint16_t ble_svc_gatt_end_handle;
+
+static uint8_t ble_svc_gatt_client_supported_features_val
+                        [CLIENT_SUPPORTED_FEATURES_MAX_OCTETS];
+static uint8_t* ble_svc_gatt_database_hash_val;
 
 static int
 ble_svc_gatt_access(uint16_t conn_handle, uint16_t attr_handle,
@@ -42,6 +55,15 @@ static const struct ble_gatt_svc_def ble_svc_gatt_defs[] = {
             .val_handle = &ble_svc_gatt_changed_val_handle,
             .flags = BLE_GATT_CHR_F_INDICATE,
         }, {
+            .uuid =
+            BLE_UUID16_DECLARE(BLE_SVC_GATT_CHR_CLIENT_SUPPORTED_FEATURES_UUID16),
+            .access_cb = ble_svc_gatt_access,
+            .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
+        }, {
+            .uuid = BLE_UUID16_DECLARE(BLE_SVC_GATT_CHR_DATABASE_HASH_UUID16),
+            .access_cb = ble_svc_gatt_access,
+            .flags = BLE_GATT_CHR_F_READ,
+        }, {
             0, /* No more characteristics in this service. */
         } },
     },
@@ -52,29 +74,96 @@ static const struct ble_gatt_svc_def ble_svc_gatt_defs[] = {
 };
 
 static int
-ble_svc_gatt_access(uint16_t conn_handle, uint16_t attr_handle,
-                    struct ble_gatt_access_ctxt *ctxt, void *arg)
-{
+ble_svc_gatt_service_changed_read_access(struct ble_gatt_access_ctxt *ctxt) {
     uint8_t *u8p;
-
-    /* The only operation allowed for this characteristic is indicate.  This
-     * access callback gets called by the stack when it needs to read the
-     * characteristic value to populate the outgoing indication command.
-     * Therefore, this callback should only get called during an attempt to
-     * read the characteristic.
-     */
-    assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
-    assert(ctxt->chr == &ble_svc_gatt_defs[0].characteristics[0]);
 
     u8p = os_mbuf_extend(ctxt->om, 4);
     if (u8p == NULL) {
-        return BLE_HS_ENOMEM;
+        return BLE_ATT_ERR_INSUFFICIENT_RES;
     }
 
     put_le16(u8p + 0, ble_svc_gatt_start_handle);
     put_le16(u8p + 2, ble_svc_gatt_end_handle);
+    return 0;
+}
+
+static int
+ble_svc_gatt_client_supported_features_read_access(
+                struct ble_gatt_access_ctxt *ctxt) {
+    int rc;
+
+    rc = os_mbuf_append(ctxt->om, ble_svc_gatt_client_supported_features_val,
+            sizeof(ble_svc_gatt_client_supported_features_val));
+
+    return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int
+ble_svc_gatt_client_supported_features_write_access(
+                        struct ble_gatt_access_ctxt *ctxt) {
+    uint16_t om_len;
+    int rc;
+
+    om_len = OS_MBUF_PKTLEN(ctxt->om);
+    if (om_len > CLIENT_SUPPORTED_FEATURES_MAX_OCTETS) {
+        return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+    }
+
+    rc = ble_hs_mbuf_to_flat(ctxt->om,
+                    ble_svc_gatt_client_supported_features_val, om_len, NULL);
+    if (rc != 0) {
+        return BLE_ATT_ERR_UNLIKELY;
+    }
 
     return 0;
+}
+
+static int
+ble_svc_gatt_database_hash_read_access(struct ble_gatt_access_ctxt *ctxt) {
+    int rc;
+    ble_svc_gatt_database_hash_val = ble_att_svr_get_database_hash();
+    rc = os_mbuf_append(ctxt->om, ble_svc_gatt_database_hash_val,
+            BLE_ATT_SVR_HASH_KEY_SIZE_IN_BYTES);
+
+    return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int
+ble_svc_gatt_access(uint16_t conn_handle, uint16_t attr_handle,
+                    struct ble_gatt_access_ctxt *ctxt, void *arg)
+{
+    uint16_t uuid16;
+    int rc;
+
+    uuid16 = ble_uuid_u16(ctxt->chr->uuid);
+    assert(uuid16 != 0);
+
+    switch (uuid16) {
+        case BLE_SVC_GATT_CHR_SERVICE_CHANGED_UUID16:
+            assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
+            rc =  ble_svc_gatt_service_changed_read_access(ctxt);
+            return rc;
+            break;
+        case BLE_SVC_GATT_CHR_CLIENT_SUPPORTED_FEATURES_UUID16:
+            if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+                rc = ble_svc_gatt_client_supported_features_read_access(ctxt);
+            } else if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+                rc = ble_svc_gatt_client_supported_features_write_access(ctxt);
+            } else {
+                assert(0);
+            }
+            return rc;
+            break;
+        case BLE_SVC_GATT_CHR_DATABASE_HASH_UUID16:
+            assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
+            ble_hs_conn_check_set_awareness_if_bonding(conn_handle, 1);
+            rc =  ble_svc_gatt_database_hash_read_access(ctxt);
+            return rc;
+            break;
+        default:
+            assert(0);
+            return BLE_ATT_ERR_UNLIKELY;
+    }
 }
 
 /**
@@ -92,6 +181,35 @@ ble_svc_gatt_changed(uint16_t start_handle, uint16_t end_handle)
     ble_gatts_chr_updated(ble_svc_gatt_changed_val_handle);
 }
 
+
+bool
+ble_svc_gatt_is_client_support_robust_caching(void) {
+   bool rc = ((ble_svc_gatt_client_supported_features_val[0] & (1 << ROBUST_CACHING)) == 1);
+   return rc;
+}
+
+int
+ble_svc_gatt_update_database_hash(void) {
+    int rc ;
+    rc = ble_att_svr_calculate_database_hash();
+    return rc;
+}
+
+static int
+ble_svc_gatt_ind_rx(struct ble_gap_event *event, void *arg)
+{
+    /* Only process connection termination events. */
+    if (event->type == BLE_GAP_EVENT_NOTIFY_TX &&
+            event->notify_tx.status == BLE_HS_EDONE &&
+            event->notify_tx.attr_handle == ble_svc_gatt_changed_val_handle) {
+
+        ble_hs_conn_check_set_awareness_if_bonding(
+                event->notify_tx.conn_handle , 1);
+    }
+
+    return 0;
+}
+
 void
 ble_svc_gatt_init(void)
 {
@@ -104,5 +222,9 @@ ble_svc_gatt_init(void)
     SYSINIT_PANIC_ASSERT(rc == 0);
 
     rc = ble_gatts_add_svcs(ble_svc_gatt_defs);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+
+    rc = ble_gap_event_listener_register(&ble_svc_gatt_gap_listener,
+            ble_svc_gatt_ind_rx, NULL);
     SYSINIT_PANIC_ASSERT(rc == 0);
 }

--- a/nimble/host/services/gatt/src/ble_svc_gatt.c
+++ b/nimble/host/services/gatt/src/ble_svc_gatt.c
@@ -38,7 +38,6 @@ static uint16_t ble_svc_gatt_end_handle;
 
 static uint8_t ble_svc_gatt_client_supported_features_val
                         [CLIENT_SUPPORTED_FEATURES_MAX_OCTETS];
-static uint8_t* ble_svc_gatt_database_hash_val;
 
 static int
 ble_svc_gatt_access(uint16_t conn_handle, uint16_t attr_handle,
@@ -74,12 +73,13 @@ static const struct ble_gatt_svc_def ble_svc_gatt_defs[] = {
 };
 
 static int
-ble_svc_gatt_service_changed_read_access(struct ble_gatt_access_ctxt *ctxt) {
+ble_svc_gatt_service_changed_read_access(struct ble_gatt_access_ctxt *ctxt)
+{
     uint8_t *u8p;
 
     u8p = os_mbuf_extend(ctxt->om, 4);
     if (u8p == NULL) {
-        return BLE_ATT_ERR_INSUFFICIENT_RES;
+        return BLE_HS_ENOMEM;
     }
 
     put_le16(u8p + 0, ble_svc_gatt_start_handle);
@@ -89,7 +89,8 @@ ble_svc_gatt_service_changed_read_access(struct ble_gatt_access_ctxt *ctxt) {
 
 static int
 ble_svc_gatt_client_supported_features_read_access(
-                struct ble_gatt_access_ctxt *ctxt) {
+                struct ble_gatt_access_ctxt *ctxt)
+{
     int rc;
 
     rc = os_mbuf_append(ctxt->om, ble_svc_gatt_client_supported_features_val,
@@ -100,7 +101,8 @@ ble_svc_gatt_client_supported_features_read_access(
 
 static int
 ble_svc_gatt_client_supported_features_write_access(
-                        struct ble_gatt_access_ctxt *ctxt) {
+                        struct ble_gatt_access_ctxt *ctxt)
+{
     uint16_t om_len;
     int rc;
 
@@ -119,8 +121,10 @@ ble_svc_gatt_client_supported_features_write_access(
 }
 
 static int
-ble_svc_gatt_database_hash_read_access(struct ble_gatt_access_ctxt *ctxt) {
+ble_svc_gatt_database_hash_read_access(struct ble_gatt_access_ctxt *ctxt)
+{
     int rc;
+    uint8_t* ble_svc_gatt_database_hash_val;
     ble_svc_gatt_database_hash_val = ble_att_svr_get_database_hash();
     rc = os_mbuf_append(ctxt->om, ble_svc_gatt_database_hash_val,
             BLE_ATT_SVR_HASH_KEY_SIZE_IN_BYTES);
@@ -183,13 +187,15 @@ ble_svc_gatt_changed(uint16_t start_handle, uint16_t end_handle)
 
 
 bool
-ble_svc_gatt_is_client_support_robust_caching(void) {
+ble_svc_gatt_is_client_robust_caching_supported(void)
+{
    bool rc = ((ble_svc_gatt_client_supported_features_val[0] & (1 << ROBUST_CACHING)) == 1);
    return rc;
 }
 
 int
-ble_svc_gatt_update_database_hash(void) {
+ble_svc_gatt_update_database_hash(void)
+{
     int rc ;
     rc = ble_att_svr_calculate_database_hash();
     return rc;

--- a/nimble/host/src/ble_att.c
+++ b/nimble/host/src/ble_att.c
@@ -468,7 +468,8 @@ ble_att_rx_handle_unknown_request(uint8_t op, uint16_t conn_handle,
 }
 
 static int
-ble_att_check_hash_uuid(uint16_t conn_handle, struct os_mbuf **rxom) {
+ble_att_check_hash_uuid(struct os_mbuf **rxom)
+{
     struct ble_att_read_req *req;
     uint16_t err_handle;
     struct ble_att_svr_entry *entry;
@@ -524,7 +525,7 @@ ble_att_rx(struct ble_l2cap_chan *chan)
          * but in case of reading hash uuid server shall respond.*/
 
         if(entry->bde_op != BLE_ATT_OP_READ_REQ ||
-                ble_att_check_hash_uuid(conn_handle,om)) {
+                ble_att_check_hash_uuid(om)) {
             ble_hs_conn_check_set_awareness_if_bonding(conn_handle, 1);
             os_mbuf_adj(*om, OS_MBUF_PKTLEN(*om));
             ble_att_svr_tx_error_rsp(conn_handle, *om, op, 0,

--- a/nimble/host/src/ble_att.c
+++ b/nimble/host/src/ble_att.c
@@ -468,6 +468,29 @@ ble_att_rx_handle_unknown_request(uint8_t op, uint16_t conn_handle,
 }
 
 static int
+ble_att_check_hash_uuid(uint16_t conn_handle, struct os_mbuf **rxom) {
+    struct ble_att_read_req *req;
+    uint16_t err_handle;
+    struct ble_att_svr_entry *entry;
+    const ble_uuid_t *uuid = BLE_UUID16_DECLARE(
+            BLE_SVC_GATT_CHR_DATABASE_HASH_UUID16);
+    /* Initialize some values in case of early error. */
+    err_handle = 0;
+    req = (struct ble_att_read_req *)(*rxom)->om_data;
+    err_handle = le16toh(req->barq_handle);
+    entry = ble_att_svr_find_by_handle(err_handle);
+
+    if (entry == NULL) {
+        return BLE_HS_ENOENT;
+    }
+    if (ble_uuid_cmp(entry->ha_uuid, uuid) == 0) {
+        return 0;
+    }
+
+    return BLE_HS_ENOTSUP;
+}
+
+static int
 ble_att_rx(struct ble_l2cap_chan *chan)
 {
     const struct ble_att_rx_dispatch_entry *entry;
@@ -495,6 +518,22 @@ ble_att_rx(struct ble_l2cap_chan *chan)
         return BLE_HS_ENOTSUP;
     }
 
+    if(!ble_hs_conn_get_awareness(conn_handle)) {
+        /* Client is not aware with the latest database updates
+         * so server ignores the command.
+         * but in case of reading hash uuid server shall respond.*/
+
+        if(entry->bde_op != BLE_ATT_OP_READ_REQ ||
+                ble_att_check_hash_uuid(conn_handle,om)) {
+            ble_hs_conn_check_set_awareness_if_bonding(conn_handle, 1);
+            os_mbuf_adj(*om, OS_MBUF_PKTLEN(*om));
+            ble_att_svr_tx_error_rsp(conn_handle, *om, op, 0,
+                    BLE_ATT_ERR_DATA_OUT_OF_SYNC);
+
+            *om = NULL;
+            return BLE_HS_EREJECT;
+        }
+    }
     ble_att_inc_rx_stat(op);
 
     /* Strip L2CAP ATT header from the front of the mbuf. */

--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -24,7 +24,6 @@
 #include "nimble/ble.h"
 #include "host/ble_uuid.h"
 #include "ble_hs_priv.h"
-
 /**
  * ATT server - Attribute Protocol
  *
@@ -43,6 +42,9 @@
  * attribute data that gets passed to the application callback.  The
  * application may choose to retain the mbuf during the callback, so the stack
  */
+#define BLE_ATT_SVR_CONCATENATE_ALL                        0x01
+#define BLE_ATT_SVR_CONCATENATE_HANDLE_TYPE      0x02
+static uint8_t ble_att_svr_database_hash[BLE_ATT_SVR_HASH_KEY_SIZE_IN_BYTES];
 
 STAILQ_HEAD(ble_att_svr_entry_list, ble_att_svr_entry);
 static struct ble_att_svr_entry_list ble_att_svr_list;
@@ -129,6 +131,78 @@ ble_att_svr_register(const ble_uuid_t *uuid, uint8_t flags,
     }
 
     return 0;
+}
+
+static uint8_t
+ble_att_svr_check_attribute_type(const ble_uuid_t * uuid) {
+    uint16_t uuid16;
+
+    uuid16 = ble_uuid_u16(uuid);
+    if( (uuid16 >= BLE_ATT_UUID_PRIMARY_SERVICE &&
+            uuid16 <= BLE_ATT_UUID_CHARACTERISTIC) ||
+            uuid16 ==  BLE_ATT_UUID_CHARACTERISTIC_EXTENDED_PROPERTIES ) {
+            return BLE_ATT_SVR_CONCATENATE_ALL;
+    } else if ( uuid16 >= BLE_ATT_UUID_CLIENT_CHARACTERISTICS_CONFIGURATION &&
+            uuid16 <= BLE_ATT_UUID_CHARACTERISTIC_AGGREGATE_FORMAT) {
+            return BLE_ATT_SVR_CONCATENATE_HANDLE_TYPE;
+    }
+    return 0;
+}
+
+/**
+ * Calculate the hash depending on the attribute in the table.
+ *
+ * @param hash_om             The buffer that contains the hash
+ *
+ * @return                      0 on success; BLE_HS_ENOMEM on error.
+ */
+int
+ble_att_svr_calculate_database_hash(void) {
+    struct ble_att_svr_entry *entry;
+    uint8_t key[BLE_ATT_SVR_HASH_KEY_SIZE_IN_BYTES];
+    struct os_mbuf *hash_om = os_msys_get(0,0);
+    struct os_mbuf *om = os_msys_get(5,0);
+    uint16_t uuid16;
+    uint8_t concatenate_status = 0;
+    int rc;
+    memset(key, 0, BLE_ATT_SVR_HASH_KEY_SIZE_IN_BYTES);
+    for (entry = STAILQ_FIRST(&ble_att_svr_list);
+         entry != NULL;
+         entry = STAILQ_NEXT(entry, ha_next)) {
+        uuid16 = ble_uuid_u16(entry->ha_uuid);
+        concatenate_status = ble_att_svr_check_attribute_type(entry->ha_uuid);
+        if (concatenate_status == BLE_ATT_SVR_CONCATENATE_ALL) {
+            rc = os_mbuf_append(hash_om,(const void*)&entry->ha_handle_id,
+                    sizeof(entry->ha_handle_id));
+            assert(rc == 0);
+            rc = os_mbuf_append(hash_om,(const void*)&uuid16,
+                    sizeof(uuid16) );
+            assert(rc == 0);
+            BLE_HS_DBG_ASSERT(entry->ha_cb != NULL);
+            rc = entry->ha_cb(0, entry->ha_handle_id,
+                            0, 0, &om, entry->ha_cb_arg);
+           rc = os_mbuf_appendfrom(hash_om,(const  struct os_mbuf *)om,0,om->om_len);
+           assert(rc == 0);
+           om->om_len = 0;
+        } else if (concatenate_status == BLE_ATT_SVR_CONCATENATE_HANDLE_TYPE) {
+            rc = os_mbuf_append(hash_om,(const void*)&entry->ha_handle_id,
+                    sizeof(entry->ha_handle_id));
+            assert(rc == 0);
+            rc = os_mbuf_append(hash_om,(const void*)&uuid16,
+                    sizeof(uuid16) );
+            assert(rc == 0);
+        }
+    }
+    rc = ble_sm_alg_aes_cmac((const uint8_t *)&key,(const uint8_t *)hash_om->om_data,
+            hash_om->om_len,(uint8_t *)&ble_att_svr_database_hash);
+    os_mbuf_free(om);
+    os_mbuf_free(hash_om);
+    return rc;
+}
+
+uint8_t*
+ble_att_svr_get_database_hash(void) {
+    return ble_att_svr_database_hash;
 }
 
 uint16_t

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1981,6 +1981,7 @@ ble_gatts_svc_set_visibility(uint16_t handle, int visible)
             } else {
                 ble_att_svr_hide_range(entry->handle, entry->end_group_handle);
             }
+            ble_hs_conn_set_all_awareness(0);
             return 0;
         }
     }

--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -520,6 +520,82 @@ ble_hs_conn_timer(void)
     return next_exp_in;
 }
 
+void
+ble_hs_conn_check_set_awareness_if_bonding(uint16_t conn_handle,
+        uint8_t aware) {
+    struct ble_store_value_sec value_sec;
+    struct ble_store_key_sec key_sec;
+    struct ble_hs_conn_addrs addrs;
+    struct ble_hs_conn *conn;
+    int rc;
+    ble_hs_lock();
+    conn = ble_hs_conn_find(conn_handle);
+    if (conn != NULL) {
+        ble_hs_conn_addrs(conn, &addrs);
+        memset(&key_sec, 0, sizeof key_sec);
+        key_sec.peer_addr = addrs.peer_id_addr;
+    }
+    ble_hs_unlock();
+
+    if (conn == NULL) {
+        rc = BLE_HS_ENOTCONN;
+    } else {
+        rc = ble_store_read_peer_sec(&key_sec, &value_sec);
+        if (rc == 0 && value_sec.ltk_present) {
+            value_sec.aware = aware;
+            rc = ble_store_write(BLE_STORE_OBJ_TYPE_CHANGE_AWARENESS,
+                    (union ble_store_value *)&value_sec);
+        }
+        ble_hs_conn_set_awareness(conn_handle,aware);
+    }
+}
+
+void
+ble_hs_conn_set_awareness(uint16_t conn_handle, uint8_t aware) {
+    struct ble_hs_conn *conn;
+    ble_hs_lock();
+    conn = ble_hs_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        ble_hs_unlock();
+        return ;
+    }
+    ble_hs_unlock();
+   conn->aware = aware;
+
+}
+
+void
+ble_hs_conn_set_all_awareness(uint8_t aware) {
+    struct ble_hs_conn *conn;
+    struct ble_store_value_sec value_sec;
+    SLIST_FOREACH(conn, &ble_hs_conns, bhc_next) {
+        conn->aware = aware;
+    }
+    value_sec.aware = aware;
+    ble_store_write(BLE_STORE_OBJ_TYPE_CHANGE_ALL_AWARENESS,
+            (union ble_store_value *)&value_sec);
+}
+
+uint8_t
+ble_hs_conn_get_awareness(uint16_t conn_handle) {
+    struct ble_hs_conn *conn;
+    ble_hs_lock();
+    conn = ble_hs_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLE_HS_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                "HANDLE=%d\n",
+                conn_handle);
+        ble_hs_unlock();
+        return BLE_HS_ENOTCONN;
+    }
+    ble_hs_unlock();
+
+    return conn->aware;
+}
+
 int
 ble_hs_conn_init(void)
 {

--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -522,7 +522,8 @@ ble_hs_conn_timer(void)
 
 void
 ble_hs_conn_check_set_awareness_if_bonding(uint16_t conn_handle,
-        uint8_t aware) {
+        uint8_t aware)
+{
     struct ble_store_value_sec value_sec;
     struct ble_store_key_sec key_sec;
     struct ble_hs_conn_addrs addrs;
@@ -551,7 +552,8 @@ ble_hs_conn_check_set_awareness_if_bonding(uint16_t conn_handle,
 }
 
 void
-ble_hs_conn_set_awareness(uint16_t conn_handle, uint8_t aware) {
+ble_hs_conn_set_awareness(uint16_t conn_handle, uint8_t aware)
+{
     struct ble_hs_conn *conn;
     ble_hs_lock();
     conn = ble_hs_conn_find(conn_handle);
@@ -562,13 +564,14 @@ ble_hs_conn_set_awareness(uint16_t conn_handle, uint8_t aware) {
         ble_hs_unlock();
         return ;
     }
-    ble_hs_unlock();
    conn->aware = aware;
+    ble_hs_unlock();
 
 }
 
 void
-ble_hs_conn_set_all_awareness(uint8_t aware) {
+ble_hs_conn_set_all_awareness(uint8_t aware)
+{
     struct ble_hs_conn *conn;
     struct ble_store_value_sec value_sec;
     SLIST_FOREACH(conn, &ble_hs_conns, bhc_next) {
@@ -580,7 +583,8 @@ ble_hs_conn_set_all_awareness(uint8_t aware) {
 }
 
 uint8_t
-ble_hs_conn_get_awareness(uint16_t conn_handle) {
+ble_hs_conn_get_awareness(uint16_t conn_handle)
+{
     struct ble_hs_conn *conn;
     ble_hs_lock();
     conn = ble_hs_conn_find(conn_handle);

--- a/nimble/host/src/ble_hs_conn_priv.h
+++ b/nimble/host/src/ble_hs_conn_priv.h
@@ -75,6 +75,7 @@ struct ble_hs_conn {
      */
     uint16_t bhc_completed_pkts;
 #endif
+    uint8_t aware;
 
     /** Queue of outgoing packets that could not be sent. */
     STAILQ_HEAD(, os_mbuf_pkthdr) bhc_tx_q;

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -566,6 +566,7 @@ ble_sm_persist_keys(struct ble_sm_proc *proc)
 
     ble_sm_fill_store_value(&peer_addr, authenticated, sc, &proc->peer_keys,
                             &value_sec);
+    value_sec.aware = 1;
     ble_store_write_peer_sec(&value_sec);
 }
 

--- a/nimble/host/src/ble_sm_alg.c
+++ b/nimble/host/src/ble_sm_alg.c
@@ -32,8 +32,8 @@
 #include "tinycrypt/constants.h"
 #include "tinycrypt/utils.h"
 
-#if MYNEWT_VAL(BLE_SM_SC)
 #include "tinycrypt/cmac_mode.h"
+#if MYNEWT_VAL(BLE_SM_SC)
 #include "tinycrypt/ecc_dh.h"
 #if MYNEWT_VAL(TRNG)
 #include "trng/trng.h"
@@ -184,16 +184,6 @@ done:
     return rc;
 }
 
-#if MYNEWT_VAL(BLE_SM_SC)
-
-static void
-ble_sm_alg_log_buf(const char *name, const uint8_t *buf, int len)
-{
-    BLE_HS_LOG(DEBUG, "    %s=", name);
-    ble_hs_log_flat_buf(buf, len);
-    BLE_HS_LOG(DEBUG, "\n");
-}
-
 /**
  * Cypher based Message Authentication Code (CMAC) with AES 128 bit
  *
@@ -202,7 +192,7 @@ ble_sm_alg_log_buf(const char *name, const uint8_t *buf, int len)
  * @param len                   Length of the message in octets.
  * @param out                   Output; message authentication code.
  */
-static int
+int
 ble_sm_alg_aes_cmac(const uint8_t *key, const uint8_t *in, size_t len,
                     uint8_t *out)
 {
@@ -222,6 +212,16 @@ ble_sm_alg_aes_cmac(const uint8_t *key, const uint8_t *in, size_t len,
     }
 
     return 0;
+}
+
+#if MYNEWT_VAL(BLE_SM_SC)
+
+static void
+ble_sm_alg_log_buf(const char *name, const uint8_t *buf, int len)
+{
+    BLE_HS_LOG(DEBUG, "    %s=", name);
+    ble_hs_log_flat_buf(buf, len);
+    BLE_HS_LOG(DEBUG, "\n");
 }
 
 int

--- a/nimble/host/src/ble_sm_priv.h
+++ b/nimble/host/src/ble_sm_priv.h
@@ -424,7 +424,9 @@ int ble_sm_init(void);
 struct ble_l2cap_chan *ble_sm_create_chan(uint16_t handle);
 void *ble_sm_cmd_get(uint8_t opcode, size_t len, struct os_mbuf **txom);
 int ble_sm_tx(uint16_t conn_handle, struct os_mbuf *txom);
-
+int
+ble_sm_alg_aes_cmac(const uint8_t *key, const uint8_t *in, size_t len,
+                    uint8_t *out);
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/host/store/ram/src/ble_store_ram.c
+++ b/nimble/host/store/ram/src/ble_store_ram.c
@@ -283,6 +283,35 @@ ble_store_ram_write_peer_sec(const struct ble_store_value_sec *value_sec)
     return 0;
 }
 
+static int
+ble_store_ram_change_awareness(const struct ble_store_value_sec *value_sec)
+{
+    struct ble_store_key_sec key_sec;
+    int idx;
+
+    BLE_HS_LOG(DEBUG, "persisting peer sec; ");
+    ble_store_ram_print_value_sec(value_sec);
+
+    ble_store_key_from_value_sec(&key_sec, value_sec);
+    idx = ble_store_ram_find_sec(&key_sec, ble_store_ram_peer_secs,
+                                 ble_store_ram_num_peer_secs);
+    if (idx == -1) {
+            return BLE_HS_ENOENT;
+        }
+
+    ble_store_ram_peer_secs[idx] = *value_sec;
+    return 0;
+}
+
+static int
+ble_store_ram_change_all_awareness(const struct ble_store_value_sec *value_sec)
+{
+    int i;
+    for (i = 0; i < ble_store_ram_num_peer_secs; i++) {
+        ble_store_ram_peer_secs[i].aware = value_sec->aware;
+    }
+    return 0;
+}
 /*****************************************************************************
  * $cccd                                                                     *
  *****************************************************************************/
@@ -450,6 +479,12 @@ ble_store_ram_write(int obj_type, const union ble_store_value *val)
 
     case BLE_STORE_OBJ_TYPE_CCCD:
         rc = ble_store_ram_write_cccd(&val->cccd);
+        return rc;
+    case BLE_STORE_OBJ_TYPE_CHANGE_ALL_AWARENESS:
+        rc = ble_store_ram_change_all_awareness(&val->sec);
+        return rc;
+    case BLE_STORE_OBJ_TYPE_CHANGE_AWARENESS:
+        rc = ble_store_ram_change_awareness(&val->sec);
         return rc;
 
     default:


### PR DESCRIPTION

Add the remaining features to support GATT caching as specified in 5.1 BLE specifications.
GATT caching is divided into:
    1-att caching.
    2-robust caching.
    3-GATT service new characteristics (service changed, database hash, client supported features).